### PR TITLE
Allow specific repos to be ignored

### DIFF
--- a/engine/policy/match.go
+++ b/engine/policy/match.go
@@ -12,13 +12,16 @@ import "github.com/drone/runner-go/manifest"
 func Match(match manifest.Match, policy []*Policy) *Policy {
 	for _, p := range policy {
 		if p.Conditions.Match(match) {
+			println("MATCHED POLICY " + p.Name)
 			return p
 		}
 	}
 	for _, p := range policy {
-		if p.Name == "default" {
+		if p.Name == "default" && !p.Exclude.Match(match) {
+			println("MATCHED DEFAULT POLICY!!")
 			return p
 		}
 	}
+	println("!!! NO POLICY WAS MATCHED !!!")
 	return nil
 }

--- a/engine/policy/policy.go
+++ b/engine/policy/policy.go
@@ -14,6 +14,7 @@ type (
 	// Policy defines pipeline defaults.
 	Policy struct {
 		Conditions     manifest.Conditions `yaml:"match"`
+		Exclude        manifest.Conditions `yaml:"ignore"`
 		Name           string
 		Metadata       Metadata
 		Resources      Resources


### PR DESCRIPTION
This should allow repos to be ignored by the runner(s), and not be assigned a default policy. This should allow the repo's builds to be picked up by another runner.

The new ignore block should be added to the default block within the policy file e.g.

    ---
    kind: policy
    name: default
    
    ignore:
      repo:
      - "b2c2/rust"
      - "b2c2/b2c2-accounting-suite"
      - "b2c2/otc_api_django"
      - "b2c2/regina"
      - "b2c2/b2c2-options-db"
      - "b2c2/refdata"
    
    metadata:
      namespace: drone-ci-builds
      labels:
        fargate: true

    resources:
      request:
        cpu: 4000
        memory: 27000MiB
      limit:
        cpu: 4000
        memory: 27000MiB
This will allow us to run two types of runners, with specific repo builds being picked up by different versions of the runner (useful for us as different versions have different behaviour with re: resources )